### PR TITLE
Containerize services, metrics dashboard, integration CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+.git
+.github
+.logs
+.services_pids
+.curl_random_pid
+infra/clickhouse
+infra/pg
+**/.env
+*.md
+slides.pdf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,22 @@ jobs:
 
       - name: Validate docker-compose
         run: docker compose -f infra/docker-compose.yml config -q
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start full stack
+        run: docker compose -f infra/docker-compose.yml up -d --build
+
+      - name: Smoke test
+        run: ./scripts/smoke-test.sh
+
+      - name: Dump logs on failure
+        if: failure()
+        run: docker compose -f infra/docker-compose.yml logs --tail 100
+
+      - name: Teardown
+        if: always()
+        run: docker compose -f infra/docker-compose.yml down -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Install deps first for layer caching
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+# Shared libs, services, and seeder
+COPY lib ./lib
+COPY src ./src
+COPY seed ./seed
+
+# Overridden per service in docker-compose (OTEL_SERVICE_NAME, PORT, entrypoint)
+CMD ["node", "--require", "./lib/otel.js", "src/gateway/app.js"]

--- a/README.md
+++ b/README.md
@@ -75,7 +75,28 @@ A companion talk is included as [`slides.pdf`](./slides.pdf).
 
 ---
 
-## Quick Start
+## Quick Start (everything in containers)
+
+One command builds the service images and starts the whole pipeline — Postgres, the seeder (runs once), the three microservices, the OTel Collector, ClickHouse, and Grafana — wired together with health-gated startup ordering:
+
+```bash
+docker compose -f infra/docker-compose.yml up -d --build
+```
+
+Then generate load and open Grafana:
+
+```bash
+make run          # random traffic against the gateway (make stop to halt)
+open http://localhost:3000   # Grafana, admin / admin
+```
+
+Tear down with `docker compose -f infra/docker-compose.yml down` (add `-v` to drop the ClickHouse/Postgres volumes).
+
+---
+
+## Local Development (services on the host)
+
+Run the infrastructure in containers but the Node services on your machine — faster iteration and live logs.
 
 ### 1. Install dependencies
 
@@ -87,8 +108,6 @@ All service dependencies resolve from the root `node_modules`.
 
 ### 2. Set up environment files
 
-Copy the example files and adjust if needed (defaults work out of the box):
-
 ```bash
 cp .env.example .env
 cp src/gateway/.env.example src/gateway/.env
@@ -98,13 +117,11 @@ cp src/orders/.env.example src/orders/.env
 
 `.env` files are git-ignored — only the `.env.example` templates are committed.
 
-### 3. Start infrastructure
+### 3. Start infrastructure only
 
 ```bash
-docker compose -f infra/docker-compose.yml up -d
+docker compose -f infra/docker-compose.yml up -d clickhouse otelcol grafana postgres
 ```
-
-Starts ClickHouse, the OTel Collector, Grafana, and Postgres.
 
 ### 4. Seed the database
 
@@ -158,7 +175,22 @@ Navigate to [http://localhost:3000](http://localhost:3000).
 
 Default credentials: `admin` / `admin`.
 
-The **otel-logs-clickhouse** dashboard is pre-provisioned and ready to use.
+Two dashboards are pre-provisioned:
+
+- **Traces** — span counts, p99 latency, error rates, a trace list, and a span/trace detail view, plus correlated logs.
+- **OTel Metrics — Gateway** — the custom `gateway_request_count` counter (cumulative timeseries + total).
+
+---
+
+## Smoke Test
+
+With the full containerized stack running, verify the pipeline end to end — routes respond and traces + the gateway metric reach ClickHouse:
+
+```bash
+./scripts/smoke-test.sh
+```
+
+This is the same check the CI `integration` job runs against a freshly built stack.
 
 ---
 
@@ -206,13 +238,17 @@ collect-ingest-observe/
 │   ├── db.js                # Postgres pool
 │   └── logger.js            # Winston logger factory
 ├── infra/
-│   ├── docker-compose.yml
+│   ├── docker-compose.yml      # Full stack: services + infra
+│   ├── clickhouse-users.xml    # Opens the default CH user to the container network
 │   ├── otel/
-│   │   └── otelcol-config.yml   # Collector: receivers, processors, exporters
-│   └── grafana/                 # Provisioned datasource + dashboard
+│   │   └── otelcol-config.yml  # Collector: receivers, processors, exporters
+│   └── grafana/                # Provisioned datasource + dashboards (traces, metrics)
 ├── seed/
 │   └── index.js             # DB seeder (faker-generated users + orders)
-├── Makefile                 # Load generation (make run / make stop)
+├── scripts/
+│   └── smoke-test.sh        # End-to-end pipeline assertion (used by CI)
+├── Dockerfile               # Shared image for the three services + seeder
+├── Makefile                 # Load generation + host service runner
 ├── slides.pdf               # Accompanying talk slides
 └── .env.example             # Environment template (copy to .env)
 ```
@@ -225,6 +261,7 @@ collect-ingest-observe/
 |----------------------|-----------------------------|-------------------------------------|
 | `OTEL_COLLECTOR_URL` | `http://localhost:4318/v1`  | OTLP HTTP exporter base URL         |
 | `OTEL_SERVICE_NAME`  | Set per service at start    | Service name reported in telemetry  |
+| `POSTGRES_HOST`      | `localhost`                 | Postgres host (`postgres` in containers) |
 | `POSTGRES_USER`      | `postgres`                  | Postgres username                   |
 | `POSTGRES_PASSWORD`  | `postgres`                  | Postgres password                   |
 | `POSTGRES_DB`        | `postgres`                  | Postgres database name              |

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,3 +1,16 @@
+x-app-base: &app-base
+  build:
+    context: ..
+    dockerfile: Dockerfile
+  image: collect-ingest-observe-app:local
+  restart: unless-stopped
+
+x-pg-env: &pg-env
+  POSTGRES_HOST: postgres
+  POSTGRES_USER: postgres
+  POSTGRES_PASSWORD: postgres
+  POSTGRES_DB: postgres
+
 services:
   otelcol:
     image: otel/opentelemetry-collector-contrib:0.74.0
@@ -62,3 +75,62 @@ services:
       interval: 5s
       timeout: 3s
       retries: 10
+
+  # One-shot: creates and seeds the Postgres tables, then exits
+  seed:
+    <<: *app-base
+    restart: "no"
+    command: ["node", "--require", "./lib/otel.js", "seed"]
+    environment:
+      <<: *pg-env
+      OTEL_SERVICE_NAME: seed-service
+      OTEL_COLLECTOR_URL: http://otelcol:4318/v1
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  users:
+    <<: *app-base
+    command: ["node", "--require", "./lib/otel.js", "src/users/app.js"]
+    environment:
+      <<: *pg-env
+      OTEL_SERVICE_NAME: user-service
+      OTEL_COLLECTOR_URL: http://otelcol:4318/v1
+      PORT: "9998"
+    depends_on:
+      otelcol:
+        condition: service_started
+      seed:
+        condition: service_completed_successfully
+
+  orders:
+    <<: *app-base
+    command: ["node", "--require", "./lib/otel.js", "src/orders/app.js"]
+    environment:
+      <<: *pg-env
+      OTEL_SERVICE_NAME: orders-service
+      OTEL_COLLECTOR_URL: http://otelcol:4318/v1
+      PORT: "9997"
+    depends_on:
+      otelcol:
+        condition: service_started
+      seed:
+        condition: service_completed_successfully
+
+  gateway:
+    <<: *app-base
+    command: ["node", "--require", "./lib/otel.js", "src/gateway/app.js"]
+    ports:
+      - "9999:9999"
+    environment:
+      <<: *pg-env
+      OTEL_SERVICE_NAME: gateway-service
+      OTEL_COLLECTOR_URL: http://otelcol:4318/v1
+      PORT: "9999"
+      USERS_URL: http://users:9998/
+      ORDERS_URL: http://orders:9997/
+    depends_on:
+      users:
+        condition: service_started
+      orders:
+        condition: service_started

--- a/infra/grafana/provisioning/dashboards/general/otel-metrics-clickhouse.json
+++ b/infra/grafana/provisioning/dashboards/general/otel-metrics-clickhouse.json
@@ -1,0 +1,350 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "schemaVersion": 38,
+  "tags": [
+    "otel",
+    "metrics"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "OTel Metrics — Gateway",
+  "uid": "otel-metrics-gateway",
+  "version": 1,
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "clickhouse-traces"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 0,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 16,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "maxDataPoints": 50,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "builderOptions": {
+            "database": "default",
+            "fields": [],
+            "filters": [
+              {
+                "condition": "AND",
+                "filterType": "custom",
+                "key": "Timestamp",
+                "operator": "WITH IN DASHBOARD TIME RANGE",
+                "restrictToFields": [
+                  {
+                    "label": "Timestamp",
+                    "name": "Timestamp",
+                    "picklistValues": [],
+                    "type": "DateTime64(9)"
+                  }
+                ],
+                "type": "datetime"
+              }
+            ],
+            "groupBy": [
+              "ServiceName"
+            ],
+            "limit": 10000,
+            "metrics": [
+              {
+                "aggregation": "count",
+                "field": ""
+              }
+            ],
+            "mode": "trend",
+            "orderBy": [],
+            "table": "otel_traces",
+            "timeField": "Timestamp",
+            "timeFieldType": "DateTime64(9)"
+          },
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse-traces"
+          },
+          "format": 0,
+          "meta": {
+            "builderOptions": {
+              "database": "default",
+              "fields": [],
+              "filters": [
+                {
+                  "condition": "AND",
+                  "filterType": "custom",
+                  "key": "Timestamp",
+                  "operator": "WITH IN DASHBOARD TIME RANGE",
+                  "restrictToFields": [
+                    {
+                      "label": "Timestamp",
+                      "name": "Timestamp",
+                      "picklistValues": [],
+                      "type": "DateTime64(9)"
+                    }
+                  ],
+                  "type": "datetime"
+                }
+              ],
+              "groupBy": [
+                "ServiceName"
+              ],
+              "limit": 10000,
+              "metrics": [
+                {
+                  "aggregation": "count",
+                  "field": ""
+                }
+              ],
+              "mode": "trend",
+              "orderBy": [],
+              "table": "otel_traces",
+              "timeField": "Timestamp",
+              "timeFieldType": "DateTime64(9)"
+            }
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT $__timeInterval(TimeUnix) as time, max(Value) as requests FROM otel_metrics_sum WHERE MetricName = 'gateway_request_count' AND $__timeFilter(TimeUnix) GROUP BY time ORDER BY time ASC",
+          "refId": "A",
+          "selectedFormat": 0
+        }
+      ],
+      "title": "Gateway request count (cumulative)",
+      "type": "timeseries",
+      "description": "OTel counter gateway_request_count, exported by the gateway service"
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "clickhouse-traces"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 2,
+      "maxDataPoints": 50,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "builderOptions": {
+            "database": "default",
+            "fields": [],
+            "filters": [
+              {
+                "condition": "AND",
+                "filterType": "custom",
+                "key": "Timestamp",
+                "operator": "WITH IN DASHBOARD TIME RANGE",
+                "restrictToFields": [
+                  {
+                    "label": "Timestamp",
+                    "name": "Timestamp",
+                    "picklistValues": [],
+                    "type": "DateTime64(9)"
+                  }
+                ],
+                "type": "datetime"
+              }
+            ],
+            "groupBy": [
+              "ServiceName"
+            ],
+            "limit": 10000,
+            "metrics": [
+              {
+                "aggregation": "count",
+                "field": ""
+              }
+            ],
+            "mode": "trend",
+            "orderBy": [],
+            "table": "otel_traces",
+            "timeField": "Timestamp",
+            "timeFieldType": "DateTime64(9)"
+          },
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse-traces"
+          },
+          "format": 0,
+          "meta": {
+            "builderOptions": {
+              "database": "default",
+              "fields": [],
+              "filters": [
+                {
+                  "condition": "AND",
+                  "filterType": "custom",
+                  "key": "Timestamp",
+                  "operator": "WITH IN DASHBOARD TIME RANGE",
+                  "restrictToFields": [
+                    {
+                      "label": "Timestamp",
+                      "name": "Timestamp",
+                      "picklistValues": [],
+                      "type": "DateTime64(9)"
+                    }
+                  ],
+                  "type": "datetime"
+                }
+              ],
+              "groupBy": [
+                "ServiceName"
+              ],
+              "limit": 10000,
+              "metrics": [
+                {
+                  "aggregation": "count",
+                  "field": ""
+                }
+              ],
+              "mode": "trend",
+              "orderBy": [],
+              "table": "otel_traces",
+              "timeField": "Timestamp",
+              "timeFieldType": "DateTime64(9)"
+            }
+          },
+          "queryType": "sql",
+          "rawSql": "SELECT max(Value) as requests FROM otel_metrics_sum WHERE MetricName = 'gateway_request_count'",
+          "refId": "A",
+          "selectedFormat": 0
+        }
+      ],
+      "title": "Total gateway requests",
+      "type": "stat",
+      "description": "Latest cumulative value of gateway_request_count"
+    }
+  ]
+}

--- a/lib/db.js
+++ b/lib/db.js
@@ -2,6 +2,7 @@ require("dotenv").config();
 const { Pool } = require("pg");
 
 const pool = new Pool({
+  host: process.env.POSTGRES_HOST || "localhost",
   user: process.env.POSTGRES_USER,
   password: process.env.POSTGRES_PASSWORD,
   database: process.env.POSTGRES_DB,

--- a/lib/otel.js
+++ b/lib/otel.js
@@ -35,6 +35,8 @@ const sdk = new NodeSDK({
     exporter: new OTLPMetricExporter({
       url: otelCollectorURL + "/metrics",
     }),
+    // Default is 60s; export every 10s so metrics show up quickly in the demo
+    exportIntervalMillis: Number(process.env.OTEL_METRIC_EXPORT_INTERVAL_MS) || 10000,
   }),
 
   instrumentations: [getNodeAutoInstrumentations()], // 🪄 The magic...

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@faker-js/faker": "10.4.0",
         "@opentelemetry/api-logs": "0.56.0",
         "@opentelemetry/auto-instrumentations-node": "0.52.0",
         "@opentelemetry/exporter-logs-otlp-http": "0.56.0",
@@ -24,7 +25,6 @@
       },
       "devDependencies": {
         "@eslint/js": "9.13.0",
-        "@faker-js/faker": "10.4.0",
         "eslint": "9.13.0",
         "globals": "15.11.0",
         "prettier": "3.3.3"
@@ -179,7 +179,6 @@
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.4.0.tgz",
       "integrity": "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "lint": "eslint . --fix"
   },
   "dependencies": {
+    "@faker-js/faker": "10.4.0",
     "@opentelemetry/api-logs": "0.56.0",
     "@opentelemetry/auto-instrumentations-node": "0.52.0",
     "@opentelemetry/exporter-logs-otlp-http": "0.56.0",
@@ -23,7 +24,6 @@
   },
   "devDependencies": {
     "@eslint/js": "9.13.0",
-    "@faker-js/faker": "10.4.0",
     "eslint": "9.13.0",
     "globals": "15.11.0",
     "prettier": "3.3.3"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# End-to-end smoke test: drives the gateway, then asserts telemetry landed in
+# ClickHouse. Assumes the full stack is already up (docker compose up -d --build).
+set -euo pipefail
+
+GW=${GATEWAY_URL:-http://localhost:9999}
+CH=${CLICKHOUSE_URL:-http://localhost:8123}
+
+echo "==> waiting for gateway at $GW"
+code=000
+for _ in $(seq 1 30); do
+  code=$(curl -s -o /dev/null -w '%{http_code}' "$GW/" || true)
+  [ "$code" = "200" ] && break
+  sleep 2
+done
+[ "$code" = "200" ] || { echo "FAIL: gateway not ready (last code $code)"; exit 1; }
+
+echo "==> checking routes"
+check() {
+  local c
+  c=$(curl -s -o /dev/null -w '%{http_code}' "$GW$1")
+  [ "$c" = "$2" ] || { echo "FAIL: $1 expected $2 got $c"; exit 1; }
+  echo "  ok $1 -> $c"
+}
+check / 200
+check /users 200
+check /orders 200
+check /users/1/orders 200
+check /error 500
+
+echo "==> generating load"
+for i in $(seq 1 20); do curl -s -o /dev/null "$GW/users/$((i % 10 + 1))/orders"; done
+
+echo "==> waiting for collector batch flush"
+sleep 10
+
+echo "==> asserting traces in ClickHouse"
+for svc in gateway-service user-service orders-service; do
+  n=$(curl -s "$CH/" --data-binary "SELECT count() FROM default.otel_traces WHERE ServiceName='$svc'")
+  echo "  $svc traces: ${n:-0}"
+  [ "${n:-0}" -gt 0 ] || { echo "FAIL: no traces for $svc"; exit 1; }
+done
+
+echo "==> asserting gateway_request_count metric"
+m=$(curl -s "$CH/" --data-binary "SELECT count() FROM default.otel_metrics_sum WHERE MetricName='gateway_request_count'")
+echo "  metric rows: ${m:-0}"
+[ "${m:-0}" -gt 0 ] || { echo "FAIL: no gateway_request_count metric"; exit 1; }
+
+echo "SMOKE TEST PASSED"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -31,8 +31,8 @@ check /error 500
 echo "==> generating load"
 for i in $(seq 1 20); do curl -s -o /dev/null "$GW/users/$((i % 10 + 1))/orders"; done
 
-echo "==> waiting for collector batch flush"
-sleep 10
+echo "==> waiting for collector batch flush + metric export interval"
+sleep 20
 
 echo "==> asserting traces in ClickHouse"
 for svc in gateway-service user-service orders-service; do

--- a/seed/index.js
+++ b/seed/index.js
@@ -6,6 +6,7 @@ const newLoger = require("../lib/logger");
 const logger = newLoger.logger(process.env.OTEL_SERVICE_NAME);
 
 const client = new Client({
+  host: process.env.POSTGRES_HOST || "localhost",
   user: process.env.POSTGRES_USER,
   password: process.env.POSTGRES_PASSWORD,
   database: process.env.POSTGRES_DB,


### PR DESCRIPTION
The three follow-up improvements, all verified against a live stack.

## 1. Metrics dashboard
New **OTel Metrics — Gateway** Grafana dashboard for the custom `gateway_request_count` counter (cumulative timeseries + total stat). The existing dashboard already covers traces (span counts, p99, error rates, trace detail) and logs, so this fills the metrics gap rather than duplicating.

## 2. Containerize the services
- `Dockerfile` — one shared image for the three services and the seeder.
- compose now defines `gateway` / `users` / `orders` plus a one-shot `seed` service, with health-gated ordering (services wait for a healthy Postgres/ClickHouse and a completed seed). `docker compose up -d --build` brings up the whole pipeline in one command.
- `db.js` + seed honor `POSTGRES_HOST` (default `localhost`; `postgres` inside containers) — this was a latent blocker for containerization.
- `@faker-js/faker` moved to `dependencies` (it's a runtime dep of the seeder).

## 3. Integration test in CI
- `scripts/smoke-test.sh` drives the gateway and asserts routes respond and traces + the gateway metric reach ClickHouse.
- New CI `integration` job builds the full stack, runs the smoke test, dumps logs on failure, and tears down.

## Verified
Built and ran the full containerized stack: seed exits 0, all services healthy, every route correct, traces for all three services + `gateway_request_count` land in ClickHouse, smoke test passes, both dashboards provisioned in Grafana. Lint + compose validation green.